### PR TITLE
Move function outside of resource to fix scope issue

### DIFF
--- a/recipes/virusscan.rb
+++ b/recipes/virusscan.rb
@@ -14,11 +14,12 @@ end
 
 ::Chef::Recipe.send(:include, Windows::Helper)
 
+is_mcafee_vs_installed = is_package_installed?(node['mcafee']['virusscan']['package_name'])
 windows_zipfile File.join(Chef::Config[:file_cache_path], node['mcafee']['virusscan']['package_name']) do
   source node['mcafee']['virusscan']['url']
   checksum node['mcafee']['virusscan']['checksum'] if node['mcafee']['virusscan']['checksum']
   action :unzip
-  not_if { is_package_installed?(node['mcafee']['virusscan']['package_name']) }
+  not_if { is_mcafee_vs_installed }
   notifies :install, "windows_package[#{node['mcafee']['virusscan']['package_name']}]", :immediately
 end
 


### PR DESCRIPTION
This fixes an issue with scope, where the is_package_installed breaks because it is expected to be a function of windows_zipfile. 

Example error:
================================================================================
           Error executing action `unzip` on resource 'windows_zipfile[C:\Users\vagrant\AppData\Local\Temp\kitchen\cache/McAfee VirusScan Enterprise]'
           ================================================================================
           
           NoMethodError
           -------------
           undefined method `is_package_installed?' for Custom resource windows_zipfile from cookbook windows
           
           Resource Declaration:
           ---------------------
           # In C:/Users/vagrant/AppData/Local/Temp/kitchen/cache/cookbooks/sbp_mcafee/recipes/virusscan.rb
           
            17: windows_zipfile File.join(Chef::Config[:file_cache_path], node['mcafee']['virusscan']['package_name']) do
            18:   source node['mcafee']['virusscan']['url']
            19:   checksum node['mcafee']['virusscan']['checksum'] if node['mcafee']['virusscan']['checksum']
            20:   action :unzip
            21:   not_if { is_package_installed?(node['mcafee']['virusscan']['package_name']) }
            22:   notifies :install, "windows_package[#{node['mcafee']['virusscan']['package_name']}]", :immediately
            23: end
            24: 
           
           Compiled Resource:
           ------------------
           # Declared in C:/Users/vagrant/AppData/Local/Temp/kitchen/cache/cookbooks/sbp_mcafee/recipes/virusscan.rb:17:in `from_file'
           
           windows_zipfile("C:\Users\vagrant\AppData\Local\Temp\kitchen\cache/McAfee VirusScan Enterprise") do
             action [:unzip]
             retries 0
             retry_delay 2
             default_guard_interpreter :default
             declared_type :windows_zipfile
             cookbook_name "sbp_mcafee"
             recipe_name "virusscan"
             source "https://artifacts.schubergphilis.com/artifacts/mcafee/VSE880LMLRP4.zip"
             checksum "1d8dec9ea50341421f4974ce6a4946f48cdbbaf53fb31f1cb392316dfbe42112"
             path "C:\\Users\\vagrant\\AppData\\Local\\Temp\\kitchen\\cache/McAfee VirusScan Enterprise"
             not_if { #code block }
           end